### PR TITLE
Disable default typechecking in @analogjs/astro-angular to avoid build errors

### DIFF
--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.mjs
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.mjs
@@ -25,6 +25,7 @@ const angularConfig = {
     transformFilter: (code, id ) => {
       return !id.includes('/packages/astro-sitecore-jss/')
     },
+    disableTypeChecking: true
   }
 }
 

--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.template.mjs
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.template.mjs
@@ -25,6 +25,7 @@ const angularConfig = {
     transformFilter: (code, id ) => {
       return !id.includes('/packages/astro-sitecore-jss/')
     },
+    disableTypeChecking: true
   }
 }
 

--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/package.json
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "ts-node --project tsconfig.scripts.json scripts/bootstrap.ts"
   },
   "dependencies": {
-    "@analogjs/astro-angular": "^1.7.0",
+    "@analogjs/astro-angular": "^1.12.0",
     "@angular-devkit/build-angular": "^18.1.3",
     "@angular/animations": "^18.1.3",
     "@angular/common": "^18.1.3",


### PR DESCRIPTION
Disable default typechecking in @analogjs/astro-angular v1.12.0 to avoid build errors