### PR TITLE
Set the original image width and height if they are not set explicitly

### DIFF
--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.mjs
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.mjs
@@ -24,8 +24,7 @@ const angularConfig = {
   vite: {
     transformFilter: (code, id ) => {
       return !id.includes('/packages/astro-sitecore-jss/')
-    },
-    disableTypeChecking: true
+    }
   }
 }
 

--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.template.mjs
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/astro.config.template.mjs
@@ -24,8 +24,7 @@ const angularConfig = {
   vite: {
     transformFilter: (code, id ) => {
       return !id.includes('/packages/astro-sitecore-jss/')
-    },
-    disableTypeChecking: true
+    }
   }
 }
 

--- a/astro-sitecore-jss/packages/astro-sitecore-jss-sample/package.json
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss-sample/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "ts-node --project tsconfig.scripts.json scripts/bootstrap.ts"
   },
   "dependencies": {
-    "@analogjs/astro-angular": "^1.12.0",
+    "@analogjs/astro-angular": "^1.12.1",
     "@angular-devkit/build-angular": "^18.1.3",
     "@angular/animations": "^18.1.3",
     "@angular/common": "^18.1.3",

--- a/astro-sitecore-jss/packages/astro-sitecore-jss/src/components/Image.astro
+++ b/astro-sitecore-jss/packages/astro-sitecore-jss/src/components/Image.astro
@@ -20,12 +20,16 @@ export interface Props extends Omit<HTMLAttributes<"img">, "src"> {
   [htmlAttributes: string]: unknown;
   field: ImageField;
   src?: string | null;
+  height?: number;
+  width?: number;
   imageParams?: { [paramName: string]: string | number };
 }
 
 const {
   field,
   src,
+  height,
+  width,
   imageParams,
   ...attrs
 } = Astro.props as Props;
@@ -35,17 +39,34 @@ if (field.editable || (!field.value || !field.value?.src)) {
   render = false;
 }
 
+const resolveDimensionNumber = (propsDimention?: number, imageFieldDimention?: string): number | undefined => {
+  if(propsDimention) {
+    return propsDimention;
+  }
+
+  if(attrs.aspectRatio) {
+    return undefined;
+  }
+
+  return parseInt(imageFieldDimention ?? "0");
+}
+
 const imageSource = prepareImageSource(
   src ?? field.value?.src ?? "",
   imageParams
 );
+
 const altText = attrs.alt ? attrs.alt : field.value?.alt ?? "";
+const imageWidth = resolveDimensionNumber(width, field.value?.width);
+const imageHeight = resolveDimensionNumber(height, field.value?.height);
 
 const getAttributes = (): any => {
   return {
     ...attrs,
-    src: imageSource,
     alt: altText,
+    src: imageSource,
+    height: imageHeight,
+    width: imageWidth
   };
 };
 ---

--- a/astro-sitecore-jss/packages/astro-vue-sitecore-jss-sample/package.json
+++ b/astro-sitecore-jss/packages/astro-vue-sitecore-jss-sample/package.json
@@ -18,7 +18,7 @@
     "bootstrap": "ts-node --project tsconfig.scripts.json scripts/bootstrap.ts"
   },
   "dependencies": {
-    "@analogjs/astro-angular": "^1.7.0",
+    "@analogjs/astro-angular": "^1.12.1",
     "@angular-devkit/build-angular": "^18.1.3",
     "@angular/animations": "^18.1.3",
     "@angular/common": "^18.1.3",


### PR DESCRIPTION
* Set width and height from Sitecore image field as fallback (the same logic as already used in AstroImage field)
* Update @analogjs/astro-angular to the latest version and remove disableTypeChecking from the Astro config. 